### PR TITLE
more bug fixes

### DIFF
--- a/src/lib/calc/const.js
+++ b/src/lib/calc/const.js
@@ -1279,6 +1279,8 @@ const ABILITIES = {
     SMOKE_TENDRILS_3: 'smoke tendrils 3',
     SMOKE_TENDRILS_4: 'smoke tendrils 4',
     SMOKE_TENDRILS: 'smoke tendrils',
+    OMNIPOWER_REGULAR: 'omnipower regular',
+    OMNIPOWER_IGNEOUS: 'omnipower igneous',
     OMNIPOWER: 'omnipower',
     TSUNAMI: 'tsunami',
     SUNSHINE_DOT: 'sunshine dot',
@@ -1321,6 +1323,7 @@ const ABILITIES = {
     BLOOD_TENDRILS_1: 'blood tendrils 1',
     BLOOD_TENDRILS_2: 'blood tendrils 2',
     BLOOD_TENDRILS: 'blood tendrils',
+    OVERPOWER_HIT: 'overpower hit',
     OVERPOWER: 'overpower',
     MASSACRE_INITIAL: 'massacre initial',
     MASSACRE_BLEED: 'massacre bleed',
@@ -1682,7 +1685,7 @@ const abils = {
             ]
         }
     },
-    [ABILITIES.OVERPOWER]: {
+    [ABILITIES.OVERPOWER_HIT]: {
         // ability name
         'min hit': 2.7, // min % of abil expressed as a decimal
         'var hit': 0.6,
@@ -1693,6 +1696,21 @@ const abils = {
         'ability type': 'ultimate', // basic, threshold, special attack, ability (necromancy classification), ultimate
         'main style': 'melee',
         'damage type': 'melee' // basic, threshold, special attack, ability (necromancy classification), ultimate
+    },
+    [ABILITIES.OVERPOWER]: {
+        // ability name
+        'min hit': 2.7, // min % of abil expressed as a decimal
+        'var hit': 0.6,
+        'on-hit effects': true, // does the ability get on-hit effects
+        'crit effects': true, // can the ability crit
+        'damage potential effects': true, // is the ability affected by damage potential
+        'ability classification': 'regular', // bleed, dot, burn, etc
+        'ability type': 'ultimate', // basic, threshold, special attack, ability (necromancy classification), ultimate
+        'main style': 'melee',
+        'damage type': 'melee',
+        hits: {
+            1: [ABILITIES.OVERPOWER_HIT]
+        }
     },
     [ABILITIES.MASSACRE_INITIAL]: {
         // ability name
@@ -3034,7 +3052,7 @@ const abils = {
             7: [ABILITIES.SMOKE_TENDRILS_4]
         }
     },
-    [ABILITIES.OMNIPOWER]: {
+    [ABILITIES.OMNIPOWER_REGULAR]: {
         // ability name
         'min hit': 2.7, // min % of abil expressed as a decimal
         'var hit': 0.6,
@@ -3045,6 +3063,32 @@ const abils = {
         'ability type': 'ultimate', // basic, threshold, special attack, ability (necromancy classification), ultimate
         'main style': 'magic',
         'damage type': 'magic' // basic, threshold, special attack, ability (necromancy classification), ultimate
+    },
+    [ABILITIES.OMNIPOWER_IGNEOUS]: {
+        // ability name
+        'min hit': 1.2, // min % of abil expressed as a decimal
+        'var hit': 0.3,
+        'on-hit effects': true, // does the ability get on-hit effects
+        'crit effects': true, // can the ability crit
+        'damage potential effects': true, // is the ability affected by damage potential
+        'ability classification': 'regular', // bleed, dot, burn, etc
+        'ability type': 'ultimate', // basic, threshold, special attack, ability (necromancy classification), ultimate
+        'main style': 'magic',
+        'damage type': 'magic' // basic, threshold, special attack, ability (necromancy classification), ultimate
+    },
+    [ABILITIES.OMNIPOWER]: {
+        // ability name
+        'min hit': 2.7, // min % of abil expressed as a decimal
+        'var hit': 0.6,
+        'on-hit effects': true, // does the ability get on-hit effects
+        'crit effects': true, // can the ability crit
+        'damage potential effects': true, // is the ability affected by damage potential
+        'ability classification': 'regular', // bleed, dot, burn, etc
+        'ability type': 'ultimate', // basic, threshold, special attack, ability (necromancy classification), ultimate
+        'main style': 'magic',
+        hits: {
+            1: [ABILITIES.OMNIPOWER_IGNEOUS, "next hit", ABILITIES.OMNIPOWER_IGNEOUS, "next hit", ABILITIES.OMNIPOWER_IGNEOUS, "next hit", ABILITIES.OMNIPOWER_IGNEOUS]
+        }
     },
     [ABILITIES.TSUNAMI]: {
         // ability name
@@ -3724,8 +3768,8 @@ const abils = {
     },
     [ABILITIES.SNIPE]: {
         // ability name
-        'min hit': 0.95, // min % of abil expressed as a decimal
-        'var hit': 0.2,
+        'min hit': 1.6, // min % of abil expressed as a decimal
+        'var hit': 0.5,
         'on-hit effects': true, // does the ability get on-hit effects
         'crit effects': true, // can the ability crit
         'damage potential effects': true, // is the ability affected by damage potential
@@ -3798,7 +3842,7 @@ const abils = {
         // ability name
         'min hit': 0.45, // min % of abil expressed as a decimal
         'var hit': 0.1,
-        'on-hit effects': true, // does the ability get on-hit effects
+        'on-hit effects': false, // does the ability get on-hit effects
         'crit effects': true, // can the ability crit
         'damage potential effects': true, // is the ability affected by damage potential
         'ability classification': 'bleed', // bleed, dot, burn, etc
@@ -3807,11 +3851,11 @@ const abils = {
         'damage type': 'ranged',
         hits: {
             1: [
-                ABILITIES.FRAGMENTATION_SHOT,
-                ABILITIES.FRAGMENTATION_SHOT,
-                ABILITIES.FRAGMENTATION_SHOT,
-                ABILITIES.FRAGMENTATION_SHOT,
-                ABILITIES.FRAGMENTATION_SHOT
+                ABILITIES.FRAGMENTATION_SHOT_HIT,
+                ABILITIES.FRAGMENTATION_SHOT_HIT,
+                ABILITIES.FRAGMENTATION_SHOT_HIT,
+                ABILITIES.FRAGMENTATION_SHOT_HIT,
+                ABILITIES.FRAGMENTATION_SHOT_HIT
             ]
         }
     },
@@ -4040,6 +4084,21 @@ const abils = {
         'ability type': 'ultimate', // basic, threshold, special attack, ability (necromancy classification), ultimate
         'main style': 'ranged',
         'damage type': 'ranged'
+    },
+    [ABILITIES.DEADSHOT]: {
+        // ability name
+        'min hit': 1.15, // min % of abil expressed as a decimal
+        'var hit': 0.2,
+        'on-hit effects': true, // does the ability get on-hit effects
+        'crit effects': true, // can the ability crit
+        'damage potential effects': true, // is the ability affected by damage potential
+        'ability classification': 'regular', // bleed, dot, burn, etc
+        'ability type': 'ultimate', // basic, threshold, special attack, ability (necromancy classification), ultimate
+        'main style': 'ranged',
+        'damage type': 'ranged',
+        hits: {
+            1: [ABILITIES.DEADSHOT_INITIAL, ABILITIES.DEADSHOT_BLEED, ABILITIES.DEADSHOT_BLEED, ABILITIES.DEADSHOT_BLEED, ABILITIES.DEADSHOT_BLEED, ABILITIES.DEADSHOT_BLEED]
+        }
     },
     [ABILITIES.DEADSHOT_BLEED]: {
         // ability name

--- a/src/lib/calc/damage_calc.js
+++ b/src/lib/calc/damage_calc.js
@@ -295,6 +295,11 @@ function ability_specific_effects(settings, dmgObject) {
             dmgObject['boosted AD'] = Math.floor(dmgObject['boosted AD'] * 1.4);
         }
 
+        // combust walk
+        if (settings['ability'] === ABILITIES.COMBUST_HIT && settings[SETTINGS.WALKED_TARGET] === true) {
+            dmgObject['boosted AD'] = Math.floor(dmgObject['boosted AD'] * 2);
+        }
+
         // wrack bound
         if (
             settings['ability'] === 'wrack' &&
@@ -338,12 +343,12 @@ function ability_specific_effects(settings, dmgObject) {
         }
 
         // slaughter walk
-        if (settings['ability'] === 'slaughter' && settings['walked'] === true) {
+        if (settings['ability'] === ABILITIES.SLAUGHTER_HIT && settings[SETTINGS.WALKED_TARGET] === true) {
             dmgObject['boosted AD'] = Math.floor(dmgObject['boosted AD'] * 3);
         }
 
         // punish low
-        if (settings['ability'] === 'punish' && settings[SETTINGS.TARGET_HP_PERCENT] <= 50) {
+        if (settings['ability'] === ABILITIES.PUNISH && settings[SETTINGS.TARGET_HP_PERCENT] <= 50) {
             dmgObject['boosted AD'] = Math.floor(dmgObject['boosted AD'] * 2.5);
         }
     }
@@ -357,6 +362,11 @@ function ability_specific_effects(settings, dmgObject) {
                 settings['target disability'] === 'stunned and bound')
         ) {
             dmgObject['boosted AD'] = Math.floor(dmgObject['boosted AD'] * 1.3);
+        }
+
+        // frag walk
+        if (settings['ability'] === ABILITIES.FRAGMENTATION_SHOT_HIT && settings[SETTINGS.WALKED_TARGET] === true) {
+            dmgObject['boosted AD'] = Math.floor(dmgObject['boosted AD'] * 2);
         }
     }
 
@@ -1537,7 +1547,7 @@ function hit_damage_calculation(settings) {
     }
 
     // handle instability (fsoa)
-    if (settings['instability'] === true && abils[settings['ability']]['damage type'] === 'magic') {
+    if (abils[settings['ability']]['crit effects'] === true && settings['instability'] === true && abils[settings['ability']]['damage type'] === 'magic') {
         total_damage += calc_fsoa(settings);
     }
 
@@ -1576,6 +1586,19 @@ function get_rotation(settings) {
             rotation[1].push('next hit');
             rotation[1].push(ABILITIES.GREATER_RICOCHET_3);
         }
+    }
+
+    if (settings['ability'] === ABILITIES.DEADSHOT && settings[SETTINGS.CAPE] === SETTINGS.CAPE_VALUES.ZUK) {
+        rotation[1].push(ABILITIES.DEADSHOT_BLEED)
+    }
+
+    if (settings['ability'] === ABILITIES.OVERPOWER && settings[SETTINGS.CAPE] === SETTINGS.CAPE_VALUES.ZUK) {
+        rotation[1].push("next hit")
+        rotation[1].push(ABILITIES.OVERPOWER_HIT)
+    }
+
+    if (settings['ability'] === ABILITIES.OMNIPOWER && settings[SETTINGS.CAPE] != SETTINGS.CAPE_VALUES.ZUK) {
+        rotation = {1:[ABILITIES.OMNIPOWER_REGULAR]}
     }
     return rotation;
 }

--- a/src/lib/calc/settings.js
+++ b/src/lib/calc/settings.js
@@ -323,7 +323,7 @@ const SETTINGS = {
         NONE: 'none',
         ZUK: 'igneous kal-zuk',
         KILN: 'tokhaar-kal-mor',
-        COMP: 'completionist',
+        COMP: 'comp/max cape',
         GOD: 'god cape',
         MAX: 'max cape',
         SKILL: 'skill cape'

--- a/src/lib/magic/abilities.js
+++ b/src/lib/magic/abilities.js
@@ -94,7 +94,7 @@ const abilities = {
     },
     [ABILITIES.OMNIPOWER]: {
         title: 'Omnipower',
-        calc: hit_damage_calculation,
+        calc: ability_damage_calculation,
         icon: '/ability_icons/magic/30x30/omnipower.png'
     },
     [ABILITIES.TSUNAMI]: {

--- a/src/lib/melee/abilities.js
+++ b/src/lib/melee/abilities.js
@@ -74,7 +74,7 @@ const abilities = {
     },
     [ABILITIES.OVERPOWER]: {
         title: 'Overpower',
-        calc: hit_damage_calculation,
+        calc: ability_damage_calculation,
         icon: '/ability_icons/melee/30x30/overpower.png'
     },
     [ABILITIES.MASSACRE]: {

--- a/src/lib/ranged/abilities.js
+++ b/src/lib/ranged/abilities.js
@@ -87,9 +87,9 @@ const abilities = {
         calc: hit_damage_calculation,
         icon: '/ability_icons/ranged/30x30/tendril.png'
     },
-    [ABILITIES.DEADSHOT_INITIAL]: {
+    [ABILITIES.DEADSHOT]: {
         title: 'Deadshot',
-        calc: hit_damage_calculation,
+        calc: ability_damage_calculation,
         icon: '/ability_icons/ranged/30x30/deadshot.png'
     },
     [ABILITIES.INCENDIARY_SHOT]: {

--- a/src/lib/ranged/abilities.js
+++ b/src/lib/ranged/abilities.js
@@ -33,7 +33,7 @@ const abilities = {
         icon: '/ability_icons/ranged/30x30/needle.png'
     },
     [ABILITIES.FRAGMENTATION_SHOT]: {
-        title: 'Fragmentation Shot',
+        title: 'Fragmentation shot',
         calc: ability_damage_calculation,
         icon: '/ability_icons/ranged/30x30/frag-shot.png'
     },


### PR DESCRIPTION
- fragmentation shot now actually calculates fragmentation shot
- updated snipe damage
- deadshot now portrays the full ability
- deadshot gets affected by zuk cape
- comp cape works now
- overpower is now affected by the zuk cape
- omnipower is now affected by zuk cape
- combust, frag, and slaughter are now affected by walked
- fsoa spec now checks if the ability can crit before applying